### PR TITLE
Add comment toggling

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,5 @@
+{
+  "comments": {
+    "lineComment": "#"
+  }
+}


### PR DESCRIPTION
This PR adds a `language-configuration.json` for the Quadlet language, so that the standard VS Code comment toggling (Ctrl+/) works as expected. 

The new `language-configuration.json` defines `#` as the line comment:

The `package.json` already includes a reference to `language-configuration.json` in the `files` section.